### PR TITLE
Add working Ruby Sinatra PayPal checkout example

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,26 @@
+# ruby-paypal-checkout-example
+
+A simple working end-to-end PayPal checkout example
+
+## Follow these steps to get everything working
+
+- Make sure you have git installed and run the following commands in your terminal:
+
+```
+git clone https://github.com/paypal/paypal-checkout-example.git
+cd paypal-checkout-example/ruby
+```
+
+- Open up checkout-example in your favorite text editor (like VSCode https://code.visualstudio.com/)
+- Find/replace all instances of "PAYPAL-SANDBOX-CLIENT-ID" with your sandbox client ID found here when you create and view your app here (you will need to log in with your business PayPal account): https://developer.paypal.com/developer/applications/
+- Find/replace all instances of "PAYPAL-SANDBOX-CLIENT-SECRET" with your sandbox secret found here when you create and view your app here (you will need to log in with your business PayPal account): https://developer.paypal.com/developer/applications/
+- Run these commands to install Ruby gems and run the Ruby Sinatra server:
+
+```
+gem install sinatra paypal-checkout-sdk
+ruby server.rb
+```
+
+- Go to http://localhost:4567 in your browser
+- Test out PayPal Checkout by clicking the payment buttons and making a purchase with your sandbox account login credentials found here: https://developer.paypal.com/developer/accounts/
+- You should see success messages in your browser console and in the terminal that's running your server

--- a/ruby/handle_paypal_request.rb
+++ b/ruby/handle_paypal_request.rb
@@ -1,0 +1,35 @@
+# 1. Import the PayPal SDK client that was created in `Set up Server-Side SDK`.
+require_relative './paypal_client'
+require 'json'
+require 'ostruct'
+
+include PayPalCheckoutSdk::Orders
+
+module Samples
+  class GetOrder
+    # 2. Set up your server to receive a call from the client
+    # You can use this function to retrieve an order by passing order ID as an argument
+    def get_order(order_id)
+      request = OrdersGetRequest::new(order_id)
+      # 3. Call PayPal to get the transaction
+      response = PayPalClient::client::execute(request)
+      # 4. Save the transaction in your database. Implement logic to save transaction to your database for future reference.
+      puts "Status Code: " + response.status_code.to_s
+      puts "Status: " + response.result.status
+      puts "Order ID: " + response.result.id
+      puts "Intent: " + response.result.intent
+      puts "Links:"
+      for link in response.result.links
+        # You could also call this link.rel or link.href, but method is a reserved keyword for RUBY. Avoid calling link.method.
+        puts "\t#{link["rel"]}: #{link["href"]}\tCall Type: #{link["method"]}"
+      end
+      puts "Gross Amount: " + response.result.purchase_units[0].amount.currency_code + response.result.purchase_units[0].amount.value
+    end
+  end
+end
+
+# This driver function invokes the get_order function
+# with order ID to retrieve sample order details.
+# if __FILE__ == $0
+#   Samples::GetOrder::new::get_order('REPLACE-WITH-VALID-ORDER-ID')
+# end

--- a/ruby/paypal_client.rb
+++ b/ruby/paypal_client.rb
@@ -1,0 +1,22 @@
+require 'paypal-checkout-sdk'
+
+module PayPalClient
+  class << self
+
+    # Set up and return PayPal Ruby SDK environment with PayPal access credentials.
+    # This sample uses SandboxEnvironment. In production, use LiveEnvironment.
+    def environment
+      client_id = ENV['PAYPAL_CLIENT_ID'] || 'PAYPAL-SANDBOX-CLIENT-ID'
+      client_secret = ENV['PAYPAL_CLIENT_SECRET'] || 'PAYPAL-SANDBOX-CLIENT-SECRET'
+
+      PayPal::SandboxEnvironment.new(client_id, client_secret)
+    end
+
+    # Returns PayPal HTTP client instance with environment that has access
+    # credentials context. Use this instance to invoke PayPal APIs, provided the
+    # credentials have access.
+    def client
+      PayPal::PayPalHttpClient.new(self.environment)
+    end
+  end
+end

--- a/ruby/public/index.html
+++ b/ruby/public/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  </head>
+
+  <body>
+    <!--
+      Change the "client-id" query parameter value below to your sandbox client ID for testing.
+      You can change it to your live client ID once you're ready for production.
+      You can find your sandbox client ID here: https://developer.paypal.com/developer/applications
+      You can click "Sandbox", then click "Create App", then click on the app to get the client ID
+      and paste it here as the query parameter.
+    -->
+    <script src="https://www.paypal.com/sdk/js?client-id=PAYPAL-SANDBOX-CLIENT-ID"></script>
+
+    <div id="paypal-button-container"></div>
+
+    <script>
+      /*
+      // The commented code below shows you an example of how you could possibly
+      // keep track of the totalOrderValueString and you can update it every time
+      // a value gets added or removed from the product cart on your website.
+
+      const productsInCart = [
+        { name: 'T-shirt', valueInCents: 1299, quantity: 2 },
+        { name: 'Pants', valueInCents: 2599, quantity: 1 }
+      ];
+
+      function getTotalOrderValueString(cart) {
+        let totalCents = 0;
+        for (const { valueInCents, quantity } of cart) {
+          totalCents += valueInCents * quantity;
+        }
+        return String(totalCents / 100);
+      }
+
+      let totalOrderValueString = getTotalOrderValueString(productsInCart);
+      */
+
+      // You can use a variable to hold the total order value of the cart
+      // and update it every time your cart changes.
+      let totalOrderValueString = '1.99';
+
+      paypal
+        .Buttons({
+          createOrder: (data, actions) => {
+            console.log('createOrder', { data, actions });
+            return actions.order.create({
+              purchase_units: [
+                {
+                  amount: {
+                    value: totalOrderValueString
+                  }
+                }
+              ]
+            });
+          },
+          onApprove: (data, actions) => {
+            return actions.order.capture().then(details => {
+              console.log('onApprove', { details });
+              return fetch('/paypal-transaction-complete', {
+                method: 'post',
+                headers: {
+                  'content-type': 'application/json'
+                },
+                body: JSON.stringify({
+                  orderID: data.orderID
+                })
+              });
+            });
+          }
+        })
+        .render('#paypal-button-container');
+    </script>
+  </body>
+</html>

--- a/ruby/server.rb
+++ b/ruby/server.rb
@@ -1,0 +1,12 @@
+require 'sinatra'
+require_relative './handle_paypal_request'
+
+get '/' do
+  send_file File.expand_path('index.html', settings.public_folder)
+end
+
+post '/paypal-transaction-complete' do
+  request.body.rewind  # in case someone already read it
+  data = JSON.parse request.body.read
+  Samples::GetOrder::new::get_order(data['orderID'])
+end


### PR DESCRIPTION
This PR adds an example that uses Ruby and the web framework Sinatra. Sinatra seems like a good choice because it's very simple and there's not much boilerplate, but Rails is more popular, so maybe we should use Rails instead or add a Rails example. For now, we can keep it simple with just Sinatra.